### PR TITLE
added case insensitive eor tag and updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ coverage
 node_modules
 package-lock.json
 tmp
+.adif
+.edi
+.adi

--- a/adif2edi
+++ b/adif2edi
@@ -131,7 +131,7 @@ function convert (arr) {
     res = [];
     obj = {};
     arr.forEach(function (e) {
-        if (e.key === 'EOR') {
+        if (e.key === 'EOR' || e.key === 'eor') {
             res.push(obj);
             obj = {};
         } else {


### PR DESCRIPTION
ADIF files which used eor instead of EOR can now be parsed